### PR TITLE
fix(sys): use `APPDIR` environment variable when running as an appimage

### DIFF
--- a/.changes/appimage.md
+++ b/.changes/appimage.md
@@ -1,0 +1,5 @@
+---
+"libappindicator-sys": patch
+---
+
+Change the library loader to use the `APPDIR` environment variable if the running application is an AppImage file.

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -11,6 +11,36 @@ use once_cell::sync::Lazy;
 use std::{os::raw::*, process::Command};
 
 pub static LIB: Lazy<Library> = Lazy::new(|| {
+  #[cfg(target_os = "linux")]
+  {
+    if let Some(appimage_path) = std::env::var_os("APPDIR") {
+      // validate that we're actually running on an AppImage
+      // an AppImage is mounted to `/$TEMPDIR/.mount_${appPrefix}${hash}`
+      // see https://github.com/AppImage/AppImageKit/blob/1681fd84dbe09c7d9b22e13cdb16ea601aa0ec47/src/runtime.c#L501
+      // note that it is safe to use `std::env::current_exe` here since we just loaded an AppImage.
+      let is_temp = std::env::current_exe()
+        .map(|p| {
+          p.display()
+            .to_string()
+            .starts_with(&format!("{}/.mount_", std::env::temp_dir().display()))
+        })
+        .unwrap_or(true);
+
+      if !is_temp {
+        panic!("`APPDIR` environment variable found but this application was not detected as an AppImage; this might be a security issue.");
+      }
+
+      let appimage_path = std::path::PathBuf::from(appimage_path);
+      let ayatana_target_path = appimage_path.join("usr/lib/libayatana-appindicator3.so");
+      let gtk_target_path = appimage_path.join("usr/lib/libappindicator3.so");
+
+      if ayatana_target_path.exists() {
+        return unsafe { Library::new(ayatana_target_path).unwrap() };
+      } else if gtk_target_path.exists() {
+        return unsafe { Library::new(gtk_target_path).unwrap() };
+      }
+    }
+  }
   // PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 pkg-config --libs-only-L ayatana-appindicator3-0.1
   let path = match get_path("ayatana-appindicator3-0.1") {
     Some(p) => format!("{}/libayatana-appindicator3.so", p),

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -42,22 +42,23 @@ pub static LIB: Lazy<Library> = Lazy::new(|| {
     }
   }
   // PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 pkg-config --libs-only-L ayatana-appindicator3-0.1
-  let path = get_library_path();
+  let path = get_appindicator_library_path();
   unsafe { Library::new(path).unwrap() }
 });
 
-/// Gets the target appindicator library path.
-pub fn get_library_path() -> PathBuf {
-  match get_path("ayatana-appindicator3-0.1") {
+/// Gets the path to the target appindicator library file (`.so` extension).
+pub fn get_appindicator_library_path() -> PathBuf {
+  match get_library_path("ayatana-appindicator3-0.1") {
     Some(p) => format!("{}/libayatana-appindicator3.so", p).into(),
-    None => match get_path("appindicator3-0.1") {
+    None => match get_library_path("appindicator3-0.1") {
       Some(p) => format!("{}/libappindicator3.so", p).into(),
       None => panic!("Can't detect any appindicator library"),
     },
   }
 }
 
-fn get_path(name: &str) -> Option<String> {
+/// Gets the folder in which a library is located using `pkg-config`.
+pub fn get_library_path(name: &str) -> Option<String> {
   let mut cmd = Command::new("pkg-config");
   cmd.env("PKG_CONFIG_ALLOW_SYSTEM_LIBS", "1");
   cmd.arg("--libs-only-L");


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [ ] Yes. Issue #___
- [ ] No


**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

@wusyong @FabianLars I know I said it would be fine to use the pkg-config thing in an AppImage, but I was wrong :joy: easier to do it this way I believe.
