### PR TITLE
fix(sys): load exclusively using dynamic linking

### DIFF
--- a/.changes/fix-dynamic-linking.md
+++ b/.changes/fix-dynamic-linking.md
@@ -1,7 +1,7 @@
 
 ---
-"libappindicator": major
-"libappindicator-sys": major
+"libappindicator": minor
+"libappindicator-sys": minor
 ---
 
 Load exclusively using dynamic linking
@@ -10,3 +10,4 @@ This change lets `dlopen` (through `ld.so`) handle what paths to search in for t
 Additionally this fixes a mistake with the library filenames. Now using the `SONAME` instead of a symlinked name that happened to work when dev packages are installed.
 
 **Breaking:** Support for `$APPDIR` based appImage detection is removed.
+Though it _should_ still work, because appimages provide an `LD_LIBRARY_PATH` that would be equivalent to what our previous detection method was doing in rust.

--- a/.changes/fix-dynamic-linking.md
+++ b/.changes/fix-dynamic-linking.md
@@ -1,0 +1,12 @@
+
+---
+"libappindicator": major
+"libappindicator-sys": major
+---
+
+Load exclusively using dynamic linking
+
+This change lets `dlopen` (through `ld.so`) handle what paths to search in for the respective libraries.
+Additionally this fixes a mistake with the library filenames. Now using the `SONAME` instead of a symlinked name that happened to work when dev packages are installed.
+
+**Breaking:** Support for `$APPDIR` based appImage detection is removed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ glib = "0.15"
 gtk = "0.15"
 gtk-sys = "0.15"
 libappindicator-sys = { version = "0.7", path = "sys/" }
+
+[features]
+default = [ "backcompat" ]
+backcompat = [ "libappindicator-sys/backcompat" ]

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -11,3 +11,7 @@ categories = [ "external-ffi-bindings" ]
 gtk-sys = "0.15"
 libloading = "0.7"
 once_cell = "1.12"
+
+[features]
+default = [ "backcompat" ]
+backcompat = [  ]


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)
<!--
If yes, please describe the impact and migration path for existing applications in an attached issue. Filing a PR with breaking changes that has not been discussed and approved by the maintainers in an issue will be immediately closed.
-->

- [x] Yes. Issue #31
- [ ] No

It would remove support for `$APPDIR` based library paths applied only inside an appimage.

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix: #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

This should let `dlopen` (through `ld.so`) handle what paths to search in for the respective libraries.

Additionally this fixes a mistake with the library filenames. Now using the `SONAME` instead of a symlinked name that happened to work when dev packages are installed.

Some major benefits:
- No more hard-coded paths, so other environments (like flatpak) can be supported.
- Removes `pkg-config` dependency, which is considered a _build tool_ and usually isn't available on a clean install.
- `LD_LIBRARY_PATH` can be used if all else fails.